### PR TITLE
feat: Add user management admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ The database schema is defined using SQLAlchemy in `src/backend/models.py`. It i
 
 The relationships between these tables are managed through association tables.
 
+## Admin Panel
+
+This project includes a web-based admin panel for managing database models, accessible at `http://localhost:8000/admin`.
+
+### Creating an Admin User
+
+To use the admin panel, you first need to create an admin user. You can do this by running the following command in your terminal:
+
+```bash
+docker compose exec backend python src/backend/create_admin.py
+```
+
+This script will prompt you to enter an email and password for the new admin user. Once created, you can use these credentials to log in to the admin panel.
+
 ## Project Structure
 
 The project is organized based on the `cookiecutter-data-science` template. Service-specific code is located under the `src/` directory.

--- a/src/backend/admin.py
+++ b/src/backend/admin.py
@@ -1,0 +1,86 @@
+"""
+Configuration for the FastAPI Admin panel.
+"""
+import os
+from fastapi_admin.app import app as admin_app
+from fastapi_admin.resources import Model
+from fastapi_admin.providers.login import UsernamePasswordProvider
+from passlib.context import CryptContext
+from .models import User, Game, Genre, Platform, Store, Tag, UserRole
+from .database import SessionLocal
+
+# In a real application, you would have a more secure way of managing the secret
+# key, e.g., by loading it from an environment variable.
+ADMIN_SECRET_KEY = os.environ.get("ADMIN_SECRET_KEY", "your-super-secret-key")
+
+# Password hashing
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# Authentication provider
+class AdminAuthProvider(UsernamePasswordProvider):
+    async def login(self, username: str, password: str) -> User:
+        db = SessionLocal()
+        user = db.query(User).filter(User.email == username).first()
+        db.close()
+
+        if not user:
+            return None
+        if not pwd_context.verify(password, user.hashed_password):
+            return None
+        if user.role != UserRole.ADMIN:
+            return None
+        return user
+
+    async def get_user(self, username: str) -> User:
+        db = SessionLocal()
+        user = db.query(User).filter(User.email == username).first()
+        db.close()
+        return user
+
+# Initialize the admin app with the auth provider
+admin_app.configure(
+    secret_key=ADMIN_SECRET_KEY,
+    auth_provider=AdminAuthProvider(),
+)
+
+@admin_app.register
+class UserAdmin(Model):
+    """Admin resource for the User model."""
+    model = User
+    icon = "fas fa-user"
+    fields = ["id", "email", "is_active", "role", "created_at"]
+
+@admin_app.register
+class GameAdmin(Model):
+    """Admin resource for the Game model."""
+    model = Game
+    icon = "fas fa-gamepad"
+    fields = ["id", "name", "slug", "released", "rating", "metacritic"]
+
+@admin_app.register
+class GenreAdmin(Model):
+    """Admin resource for the Genre model."""
+    model = Genre
+    icon = "fas fa-tag"
+    fields = ["id", "name", "slug"]
+
+@admin_app.register
+class PlatformAdmin(Model):
+    """Admin resource for the Platform model."""
+    model = Platform
+    icon = "fas fa-laptop"
+    fields = ["id", "name", "slug"]
+
+@admin_app.register
+class StoreAdmin(Model):
+    """Admin resource for the Store model."""
+    model = Store
+    icon = "fas fa-store"
+    fields = ["id", "name", "slug"]
+
+@admin_app.register
+class TagAdmin(Model):
+    """Admin resource for the Tag model."""
+    model = Tag
+    icon = "fas fa-hashtag"
+    fields = ["id", "name", "slug"]

--- a/src/backend/create_admin.py
+++ b/src/backend/create_admin.py
@@ -1,0 +1,39 @@
+"""
+A script to create an initial admin user for the Game Insight project.
+"""
+import asyncio
+from getpass import getpass
+from sqlalchemy.orm import Session
+from src.backend.database import SessionLocal
+from src.backend.models import User, UserRole
+from src.backend.admin import pwd_context
+
+async def create_admin_user():
+    """
+    Creates an admin user in the database.
+    """
+    print("Creating admin user...")
+    email = input("Admin Email: ")
+    password = getpass("Admin Password: ")
+
+    db: Session = SessionLocal()
+    user = db.query(User).filter(User.email == email).first()
+    if user:
+        print("User with this email already exists.")
+        db.close()
+        return
+
+    hashed_password = pwd_context.hash(password)
+    admin_user = User(
+        email=email,
+        hashed_password=hashed_password,
+        role=UserRole.ADMIN,
+        is_active=True,
+    )
+    db.add(admin_user)
+    db.commit()
+    db.close()
+    print(f"Admin user {email} created successfully.")
+
+if __name__ == "__main__":
+    asyncio.run(create_admin_user())

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from . import models
 from .database import engine
 from .logging import setup_logging
+from .admin import admin_app
 
 # Set up logging
 setup_logging()
@@ -17,6 +18,9 @@ app = FastAPI(
     description="API for collecting and serving video game data.",
     version="0.1.0",
 )
+
+# Mount the admin app
+app.mount("/admin", admin_app)
 
 
 @app.get("/")

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -10,3 +10,5 @@ httpx
 requests
 flower
 python-json-logger
+fastapi-admin
+passlib[bcrypt]


### PR DESCRIPTION
This commit introduces a web-based admin panel for managing users and other database models.

Key changes:
- Integrated `fastapi-admin` to provide the admin dashboard.
- Configured the admin panel in `src/backend/admin.py` with resources for all database models.
- Mounted the admin app at the `/admin` endpoint in the FastAPI application.
- Implemented a custom authentication provider to secure the admin panel with password hashing and role-based access control (only ADMIN users can log in).
- Added a script (`src/backend/create_admin.py`) to create an initial admin user from the command line.
- Updated the `README.md` with instructions on how to access the admin panel and create an admin user.