### PR TITLE
Feature/add project roadmap

### DIFF
--- a/src/backend/crud.py
+++ b/src/backend/crud.py
@@ -137,6 +137,23 @@ def get_favorite_games(db: Session, user: models.User):
     return user.favorite_games
 
 
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+from . import models, schemas
+
+def get_games_per_year(db: Session):
+    """
+    Gets the number of games released per year.
+    """
+    return db.query(func.extract('year', models.Game.released), func.count(models.Game.id)).group_by(func.extract('year', models.Game.released)).all()
+
+def get_average_rating_by_genre(db: Session):
+    """
+    Gets the average rating for each genre.
+    """
+    return db.query(models.Genre.name, func.avg(models.Game.rating)).join(models.Game.genres).group_by(models.Genre.name).all()
+
+
 def update_game(db: Session, db_game: models.Game, game_update: schemas.GameCreate):
     """
     Updates an existing game and its relationships.

--- a/src/backend/crud.py
+++ b/src/backend/crud.py
@@ -103,6 +103,40 @@ def create_game(db: Session, game: schemas.GameCreate):
     return db_game
 
 
+def get_user_by_email(db: Session, email: str):
+    """
+    Gets a user by their email address.
+    """
+    return db.query(models.User).filter(models.User.email == email).first()
+
+
+def add_favorite_game(db: Session, user: models.User, game: models.Game):
+    """
+    Adds a game to a user's list of favorite games.
+    """
+    user.favorite_games.append(game)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def remove_favorite_game(db: Session, user: models.User, game: models.Game):
+    """
+    Removes a game from a user's list of favorite games.
+    """
+    user.favorite_games.remove(game)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def get_favorite_games(db: Session, user: models.User):
+    """
+    Gets a list of a user's favorite games.
+    """
+    return user.favorite_games
+
+
 def update_game(db: Session, db_game: models.Game, game_update: schemas.GameCreate):
     """
     Updates an existing game and its relationships.

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -136,3 +136,21 @@ def get_favorites(
         raise HTTPException(status_code=403, detail="Not authorized to view this user's favorites")
 
     return crud.get_favorite_games(db=db, user=current_user)
+
+
+# --- Stats Endpoints ---
+
+@app.get("/api/stats/games-per-year")
+def get_games_per_year(db: Session = Depends(get_db)):
+    """
+    Get the number of games released per year.
+    """
+    return crud.get_games_per_year(db)
+
+
+@app.get("/api/stats/avg-rating-by-genre")
+def get_avg_rating_by_genre(db: Session = Depends(get_db)):
+    """
+    Get the average rating for each genre.
+    """
+    return crud.get_average_rating_by_genre(db)

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -81,3 +81,58 @@ def list_genres(db: Session = Depends(get_db)):
     Get a list of all genres.
     """
     return db.query(models.Genre).all()
+
+
+# --- User and Favorites Endpoints ---
+
+# Placeholder for user authentication
+def get_current_user(db: Session = Depends(get_db)):
+    # In a real app, this would be implemented with OAuth2
+    return crud.get_user_by_email(db, email="test@example.com")
+
+
+@app.post("/users/{user_id}/favorites/{game_id}", response_model=schemas.User)
+def add_favorite(
+    user_id: int,
+    game_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    # Authorization: Ensure the logged-in user can only modify their own favorites
+    if current_user.id != user_id:
+        raise HTTPException(status_code=403, detail="Not authorized to modify this user's favorites")
+
+    game = db.query(models.Game).filter(models.Game.id == game_id).first()
+    if not game:
+        raise HTTPException(status_code=404, detail="Game not found")
+
+    return crud.add_favorite_game(db=db, user=current_user, game=game)
+
+
+@app.delete("/users/{user_id}/favorites/{game_id}", response_model=schemas.User)
+def remove_favorite(
+    user_id: int,
+    game_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    if current_user.id != user_id:
+        raise HTTPException(status_code=403, detail="Not authorized to modify this user's favorites")
+
+    game = db.query(models.Game).filter(models.Game.id == game_id).first()
+    if not game:
+        raise HTTPException(status_code=404, detail="Game not found")
+
+    return crud.remove_favorite_game(db=db, user=current_user, game=game)
+
+
+@app.get("/users/{user_id}/favorites", response_model=List[schemas.Game])
+def get_favorites(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    if current_user.id != user_id:
+        raise HTTPException(status_code=403, detail="Not authorized to view this user's favorites")
+
+    return crud.get_favorite_games(db=db, user=current_user)

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -52,6 +52,13 @@ game_tags = Table(
     Column("tag_id", Integer, ForeignKey("tags.id"), primary_key=True),
 )
 
+user_favorite_games = Table(
+    "user_favorite_games",
+    Base.metadata,
+    Column("user_id", Integer, ForeignKey("users.id"), primary_key=True),
+    Column("game_id", Integer, ForeignKey("games.id"), primary_key=True),
+)
+
 
 # --- Main 'games' Table ---
 
@@ -74,9 +81,10 @@ class Game(Base):
 
     # Relationships
     genres = relationship("Genre", secondary=game_genres, back_populates="games")
-    platforms = relationship("Platform", secondary=game_platforms, back_populates="games")
+    platforms = relationship("Platform", secondary=game_platforms, back_pop_ulates="games")
     stores = relationship("Store", secondary=game_stores, back_populates="games")
     tags = relationship("Tag", secondary=game_tags, back_populates="games")
+    favorited_by = relationship("User", secondary=user_favorite_games, back_populates="favorite_games")
 
 
 # --- Look-up Tables ---
@@ -134,3 +142,6 @@ class User(Base):
     # Timestamps
     created_at = Column(DateTime, server_default=func.now())
     updated_at = Column(DateTime, onupdate=func.now())
+
+    # Relationships
+    favorite_games = relationship("Game", secondary=user_favorite_games, back_populates="favorited_by")

--- a/src/backend/schemas.py
+++ b/src/backend/schemas.py
@@ -95,3 +95,20 @@ class Game(GameBase):
 
     class Config:
         orm_mode = True
+
+
+class UserBase(BaseModel):
+    email: str
+
+
+class UserCreate(UserBase):
+    password: str
+
+
+class User(UserBase):
+    id: int
+    is_active: bool
+    favorite_games: List[Game] = []
+
+    class Config:
+        orm_mode = True

--- a/src/backend/schemas.py
+++ b/src/backend/schemas.py
@@ -97,6 +97,24 @@ class Game(GameBase):
         orm_mode = True
 
 
+# --- Schemas for Stats ---
+
+class GamesPerYearStat(BaseModel):
+    year: int
+    count: int
+
+    class Config:
+        orm_mode = True
+
+
+class AvgRatingByGenreStat(BaseModel):
+    genre: str
+    avg_rating: float
+
+    class Config:
+        orm_mode = True
+
+
 class UserBase(BaseModel):
     email: str
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -132,3 +132,17 @@ def test_remove_favorite_game(test_db):
     assert response.status_code == 200
     data = response.json()
     assert "Game C" not in [g["name"] for g in data["favorite_games"]]
+
+def test_get_games_per_year(test_db):
+    response = client.get("/api/stats/games-per-year")
+    assert response.status_code == 200
+    data = response.json()
+    assert {"year": 2023, "count": 2} in data
+    assert {"year": 2022, "count": 1} in data
+
+def test_get_avg_rating_by_genre(test_db):
+    response = client.get("/api/stats/avg-rating-by-genre")
+    assert response.status_code == 200
+    data = response.json()
+    assert {"genre": "Action", "avg_rating": (4.5 + 4.8) / 2} in data
+    assert {"genre": "RPG", "avg_rating": 3.5} in data


### PR DESCRIPTION
This pull request introduces several new features and enhancements to the backend, focusing on user favorite games, statistical endpoints, and testing. The most significant changes include the addition of CRUD operations and API endpoints for managing user favorite games, new statistical endpoints for games data, schema updates to support these features, and corresponding unit tests.

### User Favorites Management:
* Added CRUD functions in `src/backend/crud.py` to manage user favorite games, including adding, removing, and retrieving favorites.
* Introduced new endpoints in `src/backend/main.py` to handle user favorite games (`/users/{user_id}/favorites/{game_id}` for adding/removing and `/users/{user_id}/favorites` for retrieving). Includes authorization checks to ensure users can only modify their own favorites.
* Updated the `User` and `Game` models in `src/backend/models.py` to include a many-to-many relationship for favorite games using a new association table, `user_favorite_games`. [[1]](diffhunk://#diff-765ee555033cbc1c0a66d54c0e9b9df7c4ce513b94fb9925e91aa18ee452b5feR55-R61) [[2]](diffhunk://#diff-765ee555033cbc1c0a66d54c0e9b9df7c4ce513b94fb9925e91aa18ee452b5feL77-R87) [[3]](diffhunk://#diff-765ee555033cbc1c0a66d54c0e9b9df7c4ce513b94fb9925e91aa18ee452b5feR145-R147)

### Statistical Endpoints:
* Added functions in `src/backend/crud.py` to calculate the number of games released per year and the average rating by genre.
* Created new API endpoints in `src/backend/main.py` to expose these statistics: `/api/stats/games-per-year` and `/api/stats/avg-rating-by-genre`.

### Schema Updates:
* Added new Pydantic schemas in `src/backend/schemas.py` for user data (`User`, `UserCreate`) and statistical data (`GamesPerYearStat`, `AvgRatingByGenreStat`).

### Testing Enhancements:
* Updated `tests/test_api.py` to include tests for user favorite games (adding, retrieving, and removing) and the new statistical endpoints. Mocked the `get_current_user` dependency to simulate authentication in tests. [[1]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R30-R31) [[2]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79L56-R69) [[3]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R109-R148)