### PR TITLE
feat: Add user registration functionality

### DIFF
--- a/src/backend/crud.py
+++ b/src/backend/crud.py
@@ -103,11 +103,25 @@ def create_game(db: Session, game: schemas.GameCreate):
     return db_game
 
 
+from . import security
+
 def get_user_by_email(db: Session, email: str):
     """
     Gets a user by their email address.
     """
     return db.query(models.User).filter(models.User.email == email).first()
+
+
+def create_user(db: Session, user: schemas.UserCreate):
+    """
+    Creates a new user.
+    """
+    hashed_password = security.get_password_hash(user.password)
+    db_user = models.User(email=user.email, hashed_password=hashed_password)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
 
 
 def add_favorite_game(db: Session, user: models.User, game: models.Game):

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -83,7 +83,17 @@ def list_genres(db: Session = Depends(get_db)):
     return db.query(models.Genre).all()
 
 
+from fastapi import HTTPException
+
 # --- User and Favorites Endpoints ---
+
+@app.post("/api/users", response_model=schemas.User)
+def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    db_user = crud.get_user_by_email(db, email=user.email)
+    if db_user:
+        raise HTTPException(status_code=400, detail="Email already registered")
+    return crud.create_user(db=db, user=user)
+
 
 # Placeholder for user authentication
 def get_current_user(db: Session = Depends(get_db)):

--- a/src/backend/security.py
+++ b/src/backend/security.py
@@ -1,0 +1,9 @@
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password):
+    return pwd_context.hash(password)

--- a/src/frontend/app.py
+++ b/src/frontend/app.py
@@ -14,7 +14,7 @@ st.title("🎮 Game Insight Project")
 
 # --- Sidebar for Filtering and Sorting ---
 st.sidebar.header("Navigation")
-page = st.sidebar.radio("Go to", ["Home", "Profile"])
+page = st.sidebar.radio("Go to", ["Home", "Profile", "Register"])
 
 st.sidebar.header("Filter and Sort")
 
@@ -159,3 +159,23 @@ elif page == "Profile":
 
     except httpx.HTTPError as e:
         st.error(f"Failed to fetch user profile from the backend: {e}")
+
+elif page == "Register":
+    st.header("Register New User")
+    with st.form("registration_form"):
+        email = st.text_input("Email")
+        password = st.text_input("Password", type="password")
+        submitted = st.form_submit_button("Register")
+
+        if submitted:
+            try:
+                response = httpx.post(
+                    f"{BACKEND_URL}/api/users",
+                    json={"email": email, "password": password},
+                )
+                response.raise_for_status()
+                st.success("User registered successfully!")
+            except httpx.HTTPStatusError as e:
+                st.error(f"Failed to register user: {e.response.json().get('detail')}")
+            except httpx.RequestError as e:
+                st.error(f"An error occurred while registering user: {e}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -146,3 +146,21 @@ def test_get_avg_rating_by_genre(test_db):
     data = response.json()
     assert {"genre": "Action", "avg_rating": (4.5 + 4.8) / 2} in data
     assert {"genre": "RPG", "avg_rating": 3.5} in data
+
+def test_create_user(test_db):
+    response = client.post(
+        "/api/users",
+        json={"email": "newuser@example.com", "password": "newpassword"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["email"] == "newuser@example.com"
+    assert "id" in data
+
+def test_create_user_duplicate_email(test_db):
+    response = client.post(
+        "/api/users",
+        json={"email": "test@example.com", "password": "password"},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Email already registered"


### PR DESCRIPTION
This commit adds the functionality for users to register for an account.

Key changes include:
- **CRUD Function:** A `create_user` function has been added to `crud.py` to create a new user in the database.
- **API Endpoint:** A new `/api/users` endpoint has been added to handle user registration.
- **Frontend:** A new "Register" page has been added to the Streamlit application with a form to collect your email and password.
- **Security:** A `security.py` file has been added to handle password hashing.

**Testing:**
Unit tests for the new functionality have been added in `tests/test_api.py`. However, I was unable to run the tests due to a Docker permission issue in the environment. The tests are assumed to be correct.